### PR TITLE
Fix blocktranslate nested tag error

### DIFF
--- a/templates/tutorial/topics/tutorial_home.html
+++ b/templates/tutorial/topics/tutorial_home.html
@@ -19,7 +19,7 @@
     <article class="card bg-base-100 border border-base-200 shadow-sm h-full">
       <div class="card-body space-y-4">
         <div class="flex items-center justify-between text-sm uppercase tracking-wide">
-          <span class="badge badge-outline">{% blocktranslate trimmed %}Module {{ number }}{% endblocktranslate with number=forloop.counter %}</span>
+          <span class="badge badge-outline">{% blocktranslate trimmed with number=forloop.counter %}Module {{ number }}{% endblocktranslate %}</span>
           <span class="text-xs font-semibold opacity-70">{{ topic.tagline }}</span>
         </div>
         <div class="space-y-2">


### PR DESCRIPTION
Fix `TemplateSyntaxError` in `tutorial_home.html` by moving the `with` clause to the opening `blocktranslate` tag.

---
<a href="https://cursor.com/background-agent?bcId=bc-102a84f2-62e6-4905-81c8-37cccdc7af04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-102a84f2-62e6-4905-81c8-37cccdc7af04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move the `with` clause to the opening `blocktranslate` tag in `templates/tutorial/topics/tutorial_home.html` to resolve a template error.
> 
> - **Templates/i18n**:
>   - Fix `blocktranslate` usage in `templates/tutorial/topics/tutorial_home.html` by placing the `with number=forloop.counter` on the opening tag for "Module {{ number }}".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22ef167be0b54b05fd3beff3dc3aa5a9a90b2c52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->